### PR TITLE
Add 'when' command to display the hour to leave

### DIFF
--- a/jobcant/cli.py
+++ b/jobcant/cli.py
@@ -4,6 +4,7 @@ from getpass import getpass
 
 from jobcant import plotting
 from jobcant.config import Config
+from jobcant.duration import Duration
 from jobcant.jobcan import JobcanClient
 
 
@@ -22,6 +23,15 @@ def balance(exclude_last_day: bool) -> None:
     print(f"  Clock-in: {last_day[2]}")
     print(f"  Working hours: {last_day[4]}")
     print(f"  Break: {last_day[5]}")
+
+
+def when_to_leave() -> None:
+    attendance_table = _get_attendance_table()
+    leave_time = plotting.get_leave_time(attendance_table)
+    if leave_time < Duration(0):
+        print("Leave today as early as you like.")
+    else:
+        print(f"Leave today at {leave_time} to avoid overtime.")
 
 
 def update_config() -> None:
@@ -55,6 +65,8 @@ def main() -> None:
         help="Exclude last/current day from the calculation"
     )
 
+    subparsers.add_parser("when", help="Calculate at which time to leave to avoid overtime this month")
+
     subparsers.add_parser("config", help="Init or update config")
 
     graph_parser = subparsers.add_parser("graph", help="Display a graph of overtime balance over the month")
@@ -68,6 +80,8 @@ def main() -> None:
     match args.command:
         case "balance":
             balance(exclude_last_day=args.exclude_last_day)
+        case "when":
+            when_to_leave()
         case "config":
             update_config()
         case "graph":

--- a/jobcant/duration.py
+++ b/jobcant/duration.py
@@ -21,3 +21,12 @@ class Duration:
 
     def __mul__(self, other):
         return Duration(other * self.minutes)
+
+    def __lt__(self, other):
+        return self.minutes < other.minutes
+
+    def __gt__(self, other):
+        return self.minutes > other.minutes
+
+    def __abs__(self):
+        return Duration(abs(self.minutes))

--- a/jobcant/plotting.py
+++ b/jobcant/plotting.py
@@ -22,6 +22,12 @@ def get_overtime_balance(attendance_table: list[list[str]]) -> Duration:
     return sum(history, Duration())
 
 
+def get_leave_time(attendance_table: list[list[str]]) -> Duration:
+    month_balance = get_overtime_balance(attendance_table[:-1])
+    last_clock_in = Duration.parse(attendance_table[-1][2])
+    return last_clock_in + Duration(8 * 60) - month_balance
+
+
 def last_week(attendance_table: list[list[str]]) -> list[list[str]]:
     last_week_rows: list[list[str]] = []
     for row in reversed(attendance_table):


### PR DESCRIPTION
### Motivation

The purpose of this command is to display at which hour to leave on the current day to achieve a `00:00` amount of overtime for the whole month. It may be doing more or less than 8 hours on the day.

### Usage example

```bash
$ jobcant when

Leave today at 18:30 to avoid overtime.
```