### PR TITLE
'when' cmd: properly calculate including break

### DIFF
--- a/jobcant/cli.py
+++ b/jobcant/cli.py
@@ -4,7 +4,6 @@ from getpass import getpass
 
 from jobcant import plotting
 from jobcant.config import Config
-from jobcant.duration import Duration
 from jobcant.jobcan import JobcanClient
 
 
@@ -28,7 +27,8 @@ def balance(exclude_last_day: bool) -> None:
 def when_to_leave() -> None:
     attendance_table = _get_attendance_table()
     leave_time = plotting.get_leave_time(attendance_table)
-    if leave_time < Duration(0):
+    current_time = plotting.get_current_time(attendance_table)
+    if leave_time <= current_time:
         print("Leave today as early as you like.")
     else:
         print(f"Leave today at {leave_time} to avoid overtime.")

--- a/jobcant/duration.py
+++ b/jobcant/duration.py
@@ -1,6 +1,8 @@
 class Duration:
     @classmethod
     def parse(cls, duration: str):
+        if duration == "":
+            return cls(0)
         hours, minutes = duration.split(":")
         total_minutes = 60 * int(hours) + int(minutes)
         return cls(total_minutes)
@@ -27,6 +29,12 @@ class Duration:
 
     def __gt__(self, other):
         return self.minutes > other.minutes
+
+    def __le__(self, other):
+        return self.minutes <= other.minutes
+
+    def __ge__(self, other):
+        return self.minutes >= other.minutes
 
     def __abs__(self):
         return Duration(abs(self.minutes))

--- a/jobcant/plotting.py
+++ b/jobcant/plotting.py
@@ -22,10 +22,41 @@ def get_overtime_balance(attendance_table: list[list[str]]) -> Duration:
     return sum(history, Duration())
 
 
+def get_today_last_clock_in(attendance_table: list[list[str]]) -> Duration:
+    return Duration.parse(attendance_table[-1][2])
+
+
+def get_today_working_hours(attendance_table: list[list[str]]) -> Duration:
+    return Duration.parse(attendance_table[-1][4])
+
+
+def get_today_break_length(attendance_table: list[list[str]]) -> Duration:
+    return Duration.parse(attendance_table[-1][5])
+
+
+def get_current_time(attendance_table: list[list[str]]) -> Duration:
+    return (
+        get_today_last_clock_in(attendance_table) +
+        get_today_break_length(attendance_table) +
+        get_today_working_hours(attendance_table)
+    )
+
+
 def get_leave_time(attendance_table: list[list[str]]) -> Duration:
-    month_balance = get_overtime_balance(attendance_table[:-1])
-    last_clock_in = Duration.parse(attendance_table[-1][2])
-    return last_clock_in + Duration(8 * 60) - month_balance
+    day_base_hours = Duration(8 * 60)
+    min_hours_for_mandatory_break = Duration(6 * 60)
+    overtime_balance = get_overtime_balance(attendance_table[:-1])
+    last_clock_in = get_today_last_clock_in(attendance_table)
+
+    leave_time = last_clock_in + day_base_hours - overtime_balance
+
+    # When more than 6 hours must be achieved during the day,
+    # add a mandatory 1-hour break time.
+    required_today = day_base_hours - overtime_balance
+    if required_today > min_hours_for_mandatory_break:
+        leave_time += Duration(60)
+
+    return leave_time
 
 
 def last_week(attendance_table: list[list[str]]) -> list[list[str]]:


### PR DESCRIPTION
These changes would include the required 1-hour break time in the calculation for "when to leave".

It depends how many hours are required to achieve the day, as it would include a 1-hour break.
- Less than 6 hours required: break is deducted / base hours for the day: 8h.
- More than 6 hours required: break is included / base hours for the day: 9h.

Also, if at the moment `jobcant when` is executed, the time to leave has passed, it now says to go home. This is to prevent telling the user to leave in the past.